### PR TITLE
로그아웃 링크 동작하지 않는 오류 수정

### DIFF
--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -2,16 +2,19 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light border-bottom">
     <a class="navbar-brand" href="{% url 'pybo:index' %}">Pybo</a>
     <button class="navbar-toggler ml-auto" type="button" data-toggle="collapse" data-target="#navbarNav"
-        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse flex-grow-0" id="navbarNav">
         <ul class="navbar-nav">
             <li class="nav-item ">
                 {% if user.is_authenticated %}
-                <a class="nav-link" href="{% url 'common:logout' %}">{{ user.username }} (로그아웃)</a>
+                    <form method="post" action="{% url 'common:logout' %}">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-link nav-link">{{ user.username }} (로그아웃)</button>
+                    </form>
                 {% else %}
-                <a class="nav-link" href="{% url 'common:login' %}">로그인</a>
+                    <a class="nav-link" href="{% url 'common:login' %}">로그인</a>
                 {% endif %}
             </li>
         </ul>


### PR DESCRIPTION
- 로그아웃 링크를 csrf_token 을 포함한 POST 요청으로 교체
- 사용자가 로그아웃을 원할 때 버튼을 클릭하면 post 방식으로 'common:logout' url로 요청이 보내집니다.